### PR TITLE
Include charset

### DIFF
--- a/sass/_zass.scss
+++ b/sass/_zass.scss
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 //Copyright 2011, Marc Busqué Pérez
 //
 //This file is a part of Zass.


### PR DESCRIPTION
I got into this error:

```
Syntax error: Invalid US-ASCII character "\xC3"
        on line 1 of /home/vagrant/vendor/waiting-for-dev/zass/sass/_zass.scss
        from line 25 of /tmp/assetic_sassT8Vg1P
  Use --trace for backtrace.
```

Related https://github.com/sass/sass/issues/189.
